### PR TITLE
Add galaxy starfield background and warp menu

### DIFF
--- a/components/StarField.tsx
+++ b/components/StarField.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useRef } from 'react';
+
+interface Star {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+}
+
+export default function StarField() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const pointer = useRef({ x: 0, y: 0 });
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const resize = () => {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+    };
+    resize();
+    window.addEventListener('resize', resize);
+
+    const starCount = Math.min(150, Math.floor((canvas.width * canvas.height) / 8000));
+    const stars: Star[] = [];
+    for (let i = 0; i < starCount; i++) {
+      stars.push({
+        x: Math.random() * canvas.width,
+        y: Math.random() * canvas.height,
+        vx: (Math.random() - 0.5) * 0.5,
+        vy: (Math.random() - 0.5) * 0.5,
+      });
+    }
+
+    const connectDist = 120;
+    let animationId: number;
+
+    const animate = () => {
+      if (!ctx) return;
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+      for (const star of stars) {
+        const dx = pointer.current.x - star.x;
+        const dy = pointer.current.y - star.y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        if (dist < 100) {
+          star.vx += dx * 0.0005;
+          star.vy += dy * 0.0005;
+        }
+        star.x += star.vx;
+        star.y += star.vy;
+
+        if (star.x < 0 || star.x > canvas.width) star.vx *= -1;
+        if (star.y < 0 || star.y > canvas.height) star.vy *= -1;
+      }
+
+      ctx.fillStyle = 'white';
+      for (const star of stars) {
+        ctx.beginPath();
+        ctx.arc(star.x, star.y, 2, 0, Math.PI * 2);
+        ctx.fill();
+      }
+
+      ctx.strokeStyle = 'rgba(255,255,255,0.2)';
+      ctx.lineWidth = 0.5;
+      for (let i = 0; i < stars.length; i++) {
+        for (let j = i + 1; j < stars.length; j++) {
+          const a = stars[i];
+          const b = stars[j];
+          const dx = a.x - b.x;
+          const dy = a.y - b.y;
+          const distSq = dx * dx + dy * dy;
+          if (distSq < connectDist * connectDist) {
+            ctx.beginPath();
+            ctx.moveTo(a.x, a.y);
+            ctx.lineTo(b.x, b.y);
+            ctx.stroke();
+          }
+        }
+      }
+
+      animationId = requestAnimationFrame(animate);
+    };
+
+    animate();
+
+    const handleMove = (e: PointerEvent) => {
+      pointer.current.x = e.clientX;
+      pointer.current.y = e.clientY;
+    };
+    window.addEventListener('pointermove', handleMove);
+
+    return () => {
+      cancelAnimationFrame(animationId);
+      window.removeEventListener('resize', resize);
+      window.removeEventListener('pointermove', handleMove);
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="fixed top-0 left-0 w-full h-full z-0" />;
+}

--- a/pages/about/index.tsx
+++ b/pages/about/index.tsx
@@ -1,0 +1,15 @@
+import StarField from '../../components/StarField';
+import Link from 'next/link';
+
+export default function About() {
+  return (
+    <main className="min-h-screen text-white relative overflow-hidden bg-black">
+      <StarField />
+      <div className="relative z-10 p-8">
+        <Link href="/" className="text-cyan-300 underline">Home</Link>
+        <h1 className="text-4xl font-bold mt-8 mb-4">About</h1>
+        <p>EternaCode is an AI-driven company building the future.</p>
+      </div>
+    </main>
+  );
+}

--- a/pages/contact/index.tsx
+++ b/pages/contact/index.tsx
@@ -1,0 +1,15 @@
+import StarField from '../../components/StarField';
+import Link from 'next/link';
+
+export default function Contact() {
+  return (
+    <main className="min-h-screen text-white relative overflow-hidden bg-black">
+      <StarField />
+      <div className="relative z-10 p-8">
+        <Link href="/" className="text-cyan-300 underline">Home</Link>
+        <h1 className="text-4xl font-bold mt-8 mb-4">Contact</h1>
+        <p>Reach out to us at contact@eternacode.ai.</p>
+      </div>
+    </main>
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,102 +1,39 @@
-import { useState, useRef, useEffect } from 'react';
-import { Canvas, useFrame } from '@react-three/fiber';
-import { OrbitControls } from '@react-three/drei';
-import { Globe } from 'lucide-react';
-
-const localeText = {
-  en: {
-    title: 'EternaCode',
-    slogan: 'Code Eternal. Mind Unbound.',
-    description: 'A fully AI-operated company creating next-generation apps and web services.',
-    products: 'Our Products',
-    apps: 'Apps',
-    web: 'Web Services',
-  },
-  ko: {
-    title: '이터나코드',
-    slogan: '영원한 코드, 자유로운 지성.',
-    description: '다음 세대를 위한 앱과 웹 서비스를 만드는 완전 자동화된 AI 기업입니다.',
-    products: '제품 소개',
-    apps: '앱',
-    web: '웹 서비스',
-  },
-  ja: {
-    title: 'エターナコード',
-    slogan: '永遠のコード、解き放たれた知性。',
-    description: '次世代のアプリとWebサービスを創造する、完全AI運営企業。',
-    products: '製品紹介',
-    apps: 'アプリ',
-    web: 'ウェブサービス',
-  },
-};
-
-function RotatingSphere() {
-  const ref = useRef();
-  useFrame(() => {
-    if (ref.current) {
-      ref.current.rotation.y += 0.003;
-      ref.current.rotation.x += 0.001;
-    }
-  });
-  return (
-    <mesh ref={ref} scale={1.5}>
-      <icosahedronGeometry args={[1, 1]} />
-      <meshStandardMaterial color="#00c8a2" wireframe />
-    </mesh>
-  );
-}
+import { Star } from 'lucide-react';
+import StarField from '../components/StarField';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
 
 export default function Home() {
-  const [locale, setLocale] = useState('en');
-  const t = localeText[locale];
+  const router = useRouter();
+  const [warp, setWarp] = useState('');
+
+  const handleWarp = (path: string) => {
+    setWarp(path);
+    setTimeout(() => router.push(path), 300);
+  };
+
+  const starClass = (path: string) =>
+    `transition-transform duration-300 ${warp === path ? 'scale-150' : 'hover:scale-125'}`;
 
   return (
     <main className="min-h-screen bg-black text-white relative overflow-hidden">
-      <Canvas className="absolute top-0 left-0 w-full h-full z-0">
-        <ambientLight intensity={0.5} />
-        <pointLight position={[5, 5, 5]} />
-        <RotatingSphere />
-        <OrbitControls enableZoom={false} autoRotate autoRotateSpeed={1.5} />
-      </Canvas>
-
-      <div className="relative z-10 p-8">
-        <header className="flex justify-between items-center mb-10">
-          <img src="/eternacode-logo.png" alt="EternaCode Logo" className="h-10" />
-          <div className="flex gap-2 items-center">
-            <Globe className="w-5 h-5" />
-            <select
-              value={locale}
-              onChange={(e) => setLocale(e.target.value)}
-              className="bg-black text-white border border-gray-700 px-2 py-1 rounded"
-            >
-              <option value="en">EN</option>
-              <option value="ko">KO</option>
-              <option value="ja">JA</option>
-            </select>
-          </div>
-        </header>
-
-        <section className="text-center mt-20">
-          <h1 className="text-5xl font-bold mb-4 text-cyan-400">{t.title}</h1>
-          <p className="text-2xl text-gray-300 mb-6">{t.slogan}</p>
-          <p className="max-w-2xl mx-auto text-gray-400 mb-12">{t.description}</p>
-        </section>
-
-        <section className="text-center">
-          <h2 className="text-2xl font-semibold mb-4 text-cyan-300">{t.products}</h2>
-          <div className="flex justify-center gap-6">
-            <div className="bg-gray-800 p-4 rounded shadow-lg w-40">
-              <p className="font-medium text-white">{t.apps}</p>
-            </div>
-            <div className="bg-gray-800 p-4 rounded shadow-lg w-40">
-              <p className="font-medium text-white">{t.web}</p>
-            </div>
-          </div>
-        </section>
-
-        <footer className="mt-24 text-center text-sm text-gray-500">
-          &copy; {new Date().getFullYear()} EternaCode. All rights reserved.
-        </footer>
+      <StarField />
+      <div className="relative z-10 flex flex-col items-center justify-center min-h-screen p-4 text-center">
+        <h1 className="text-4xl md:text-6xl font-bold mb-10">Eterna Galaxy</h1>
+        <div className="flex gap-12">
+          <button onClick={() => handleWarp('/about')} className={starClass('/about')}>
+            <Star className="w-12 h-12 text-yellow-300" />
+            <span className="sr-only">About</span>
+          </button>
+          <button onClick={() => handleWarp('/product')} className={starClass('/product')}>
+            <Star className="w-12 h-12 text-yellow-300" />
+            <span className="sr-only">Product</span>
+          </button>
+          <button onClick={() => handleWarp('/contact')} className={starClass('/contact')}>
+            <Star className="w-12 h-12 text-yellow-300" />
+            <span className="sr-only">Contact</span>
+          </button>
+        </div>
       </div>
     </main>
   );

--- a/pages/product/index.tsx
+++ b/pages/product/index.tsx
@@ -1,0 +1,15 @@
+import StarField from '../../components/StarField';
+import Link from 'next/link';
+
+export default function Product() {
+  return (
+    <main className="min-h-screen text-white relative overflow-hidden bg-black">
+      <StarField />
+      <div className="relative z-10 p-8">
+        <Link href="/" className="text-cyan-300 underline">Home</Link>
+        <h1 className="text-4xl font-bold mt-8 mb-4">Product</h1>
+        <p>Discover our cutting-edge apps and services.</p>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `StarField` component with interactive canvas animation
- redesign home page with starfield background and star-shaped menu
- add About, Product, and Contact pages using same starfield backdrop

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68577d5963f08332a10ae9fdbcc66225